### PR TITLE
Push Docker images to Harbor registry and improve build speed

### DIFF
--- a/.github/workflows/docker_push_beta.yml
+++ b/.github/workflows/docker_push_beta.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Build and Deploy Image
         run: |
             docker buildx build --push \
-                --tag kumpeapps-bot/shipping_bot:latest-beta \
+                --tag harbor.vm.kumpeapps.com/kumpeapps-bot/shipping_bot:latest-beta \
                 --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/.github/workflows/docker_push_beta.yml
+++ b/.github/workflows/docker_push_beta.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           buildx-version: latest
       - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        run: echo "${{ secrets.HARBOR_SECRET }}" | docker login harbor.vm.kumpeapps.com -u "robot$github" --password-stdin
       - name: Build and Deploy Image
         run: |
             docker buildx build --push \
-                --tag justinkumpe/shipping_bot:latest-beta \
+                --tag kumpeapps-bot/shipping_bot:latest-beta \
                 --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/.github/workflows/docker_push_beta.yml
+++ b/.github/workflows/docker_push_beta.yml
@@ -1,11 +1,16 @@
 name: Push Docker Image to Docker Hub (Beta)
 
+concurrency:
+  group: "docker-push-beta"
+  cancel-in-progress: true
+
 on:
   push:
     branches: PreProd
 
 jobs:
-  deploy:
+  deploymnet:
+    environment: beta
     env:
       DOCKER_CLIENT_TIMEOUT: 300
       COMPOSE_HTTP_TIMEOUT: 300

--- a/.github/workflows/docker_push_beta.yml
+++ b/.github/workflows/docker_push_beta.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           buildx-version: latest
       - name: Login to Docker Hub
-        run: echo "${{ secrets.HARBOR_SECRET }}" | docker login harbor.vm.kumpeapps.com -u "robot$github" --password-stdin
+        run: echo "${{ secrets.HARBOR_SECRET }}" | docker login harbor.vm.kumpeapps.com -u "robot_github" --password-stdin
       - name: Build and Deploy Image
         run: |
             docker buildx build --push \

--- a/.github/workflows/docker_push_beta.yml
+++ b/.github/workflows/docker_push_beta.yml
@@ -9,7 +9,7 @@ on:
     branches: PreProd
 
 jobs:
-  deploymnet:
+  deployment:
     environment: beta
     env:
       DOCKER_CLIENT_TIMEOUT: 300

--- a/.github/workflows/docker_push_beta.yml
+++ b/.github/workflows/docker_push_beta.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   deploy:
+    env:
+      DOCKER_CLIENT_TIMEOUT: 300
+      COMPOSE_HTTP_TIMEOUT: 300
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/docker_push_latest.yml
+++ b/.github/workflows/docker_push_latest.yml
@@ -1,11 +1,15 @@
 name: Push Docker Image to Docker Hub (Latest)
 
+concurrency:
+  group: "docker-push-latest"
+  cancel-in-progress: true
 on:
   push:
     branches: master
 
 jobs:
-  deploy:
+  deploymnet:
+    environment: production
     env:
       DOCKER_CLIENT_TIMEOUT: 300
       COMPOSE_HTTP_TIMEOUT: 300

--- a/.github/workflows/docker_push_latest.yml
+++ b/.github/workflows/docker_push_latest.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   deploy:
+    env:
+      DOCKER_CLIENT_TIMEOUT: 300
+      COMPOSE_HTTP_TIMEOUT: 300
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -16,9 +19,9 @@ jobs:
         with:
           buildx-version: latest
       - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        run: echo "${{ secrets.HARBOR_SECRET }}" | docker login harbor.vm.kumpeapps.com -u "robot_github" --password-stdin
       - name: Build and Deploy Image
         run: |
             docker buildx build --push \
-                --tag justinkumpe/shipping_bot:latest \
+                --tag harbor.vm.kumpeapps.com/kumpeapps-bot/shipping_bot:latest \
                 --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/.github/workflows/docker_push_latest.yml
+++ b/.github/workflows/docker_push_latest.yml
@@ -8,7 +8,7 @@ on:
     branches: master
 
 jobs:
-  deploymnet:
+  deployment:
     environment: production
     env:
       DOCKER_CLIENT_TIMEOUT: 300

--- a/.github/workflows/docker_push_release.yml
+++ b/.github/workflows/docker_push_release.yml
@@ -1,5 +1,9 @@
 name: Push Docker Image to Docker Hub (Release)
 
+concurrency:
+  group: "docker-push-release"
+  cancel-in-progress: true
+
 on:
   release:
     types: [published]

--- a/.github/workflows/docker_push_release.yml
+++ b/.github/workflows/docker_push_release.yml
@@ -9,7 +9,7 @@ on:
     types: [published]
 
 jobs:
-  deploy:
+  release:
     env:
       DOCKER_CLIENT_TIMEOUT: 300
       COMPOSE_HTTP_TIMEOUT: 300

--- a/.github/workflows/docker_push_release.yml
+++ b/.github/workflows/docker_push_release.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   deploy:
+    env:
+      DOCKER_CLIENT_TIMEOUT: 300
+      COMPOSE_HTTP_TIMEOUT: 300
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -16,9 +19,9 @@ jobs:
         with:
           buildx-version: latest
       - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        run: echo "${{ secrets.HARBOR_SECRET }}" | docker login harbor.vm.kumpeapps.com -u "robot_github" --password-stdin
       - name: Build and Deploy Image
         run: |
             docker buildx build --push \
-                --tag justinkumpe/shipping_bot:${{ github.ref_name }} \
+                --tag harbor.vm.kumpeapps.com/kumpeapps-bot/shipping_bot:${{ github.ref_name }} \
                 --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1
-COPY . /app
 WORKDIR /app
-
+COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
+COPY . /app
 
 CMD [ "python", "get_emails.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY requirements.txt /app/
+# Note: If additional files required for dependency installation (e.g., setup.py, pyproject.toml) are needed,
+# copy them here to maintain efficient caching.
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 


### PR DESCRIPTION
## Summary by Sourcery

Update Docker deployment workflows to push images to Harbor registry instead of Docker Hub, and update Dockerfiles to improve build speed.

Build:
- Update Dockerfiles to copy requirements.txt first, then install dependencies, and finally copy the rest of the application files.
- Set DOCKER_CLIENT_TIMEOUT and COMPOSE_HTTP_TIMEOUT environment variables to 300 seconds in the Docker deployment jobs.

Deployment:
- Update Docker deployment workflows to push images to Harbor registry instead of Docker Hub.