### PR TITLE
Disable PitneyShip email scraping

### DIFF
--- a/get_emails.py
+++ b/get_emails.py
@@ -23,9 +23,11 @@ def parse_data(message: dict) -> dict:
             message.subject == "[PitneyShip] Package Shipped"
             or message.subject == "A shipment from Angela Kumpe is on its way"
         ):
-            parsed_data = scrape_pitneyship(message.html)
-            parsed_data["status"] = "shipped"
-            parsed_data["flow_status"] = "processing"
+            # parsed_data = scrape_pitneyship(message.html)
+            # parsed_data["status"] = "shipped"
+            # parsed_data["flow_status"] = "processing"
+            parsed_data["status"] = "unknown"
+            parsed_data["flow_status"] = "rejected"
         elif (
             message.subject == "[PitneyShip] Package Delivered"
             or message.subject == "Shipment Delivered"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Disable previous PitneyShip email scraping logic and set default status to 'unknown' and flow status to 'rejected'