### PR TITLE
Revert "Install and configure cron job in Dockerfile"

### DIFF
--- a/.github/workflows/docker_push_beta.yml
+++ b/.github/workflows/docker_push_beta.yml
@@ -12,8 +12,8 @@ jobs:
   deployment:
     environment: beta
     env:
-      DOCKER_CLIENT_TIMEOUT: 600
-      COMPOSE_HTTP_TIMEOUT: 600
+      DOCKER_CLIENT_TIMEOUT: 300
+      COMPOSE_HTTP_TIMEOUT: 300
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,10 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY requirements.txt /app/
-COPY crontab_file /etc/cron.d/my_cron
-RUN apt-get update && apt-get install -y cron
-RUN apt-get clean
 # Note: If additional files required for dependency installation (e.g., setup.py, pyproject.toml) are needed,
 # copy them here to maintain efficient caching.
 RUN pip install --no-cache-dir -r requirements.txt
-RUN service cron start
 COPY . /app
-RUN chmod 0644 /etc/cron.d/my_cron
-# RUN crontab /etc/cron.d/my_cron
 
-CMD [ "cron", "-f" ]
+CMD [ "python", "get_emails.py" ]

--- a/crontab_file
+++ b/crontab_file
@@ -1,1 +1,0 @@
-0 * * * * /app/get_emails.py

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,6 +1,6 @@
 services:
   shipping_bot:
-    image: "harbor.vm.kumpeapps.com/kumpeapps-bot/shipping_bot:latest-beta"
+    image: "justinkumpe/shipping_bot:latest-beta"
     environment:
       - EMAIL=
       - FROM_EMAIL=


### PR DESCRIPTION
Reverts kumpeapps/Shipping-Bot#20

## Summary by Sourcery

Revert the previous changes that added cron job configuration to the Dockerfile

Deployment:
- Simplified Docker image by removing cron installation and configuration
- Reduced Docker image timeout from 600 to 300 seconds in GitHub workflow

Chores:
- Remove cron-related configurations and dependencies from the Dockerfile