### PR TITLE
Replace cron with in-script scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 
-RUN /app/get_emails.py
+CMD ["python", "get_emails.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,10 @@ FROM python:3.11-slim-bookworm
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY requirements.txt /app/
-COPY crontab_file /etc/cron.d/my_cron
-RUN apt-get update && apt-get install -y cron
-RUN apt-get clean
+
 # Note: If additional files required for dependency installation (e.g., setup.py, pyproject.toml) are needed,
 # copy them here to maintain efficient caching.
 RUN pip install --no-cache-dir -r requirements.txt
 RUN service cron start
 COPY . /app
-RUN chmod 0644 /etc/cron.d/my_cron
-# RUN crontab /etc/cron.d/my_cron
-
-CMD [ "cron", "-f" ]
+RUN /app/get_emails.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 
 USER non-root
+RUN chown -R non-root:non-root /app
 CMD ["python", "get_emails.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 
-USER non-root
+RUN groupadd -r non-root && useradd -r -g non-root non-root
 RUN chown -R non-root:non-root /app
+USER non-root
 CMD ["python", "get_emails.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 
+USER non-root
 CMD ["python", "get_emails.py"]

--- a/crontab_file
+++ b/crontab_file
@@ -1,1 +1,0 @@
-0 * * * * /app/get_emails.py

--- a/get_emails.py
+++ b/get_emails.py
@@ -352,5 +352,7 @@ if __name__ == "__main__":
     schedule.every().hour.do(fetch_emails)
     while not shutdown:
         schedule.run_pending()
-        time.sleep(20)  # Sleep for 20 seconds before checking again
+        idle = schedule.idle_seconds()
+        # Sleep for the lesser of idle time or 1 second for responsive shutdown
+        time.sleep(min(idle if idle is not None else 1, 1))
     logger.info("Shipping Bot stopped.")

--- a/get_emails.py
+++ b/get_emails.py
@@ -339,4 +339,4 @@ if __name__ == "__main__":
     schedule.every().hour.do(fetch_emails)
     while True:
         schedule.run_pending()
-        time.sleep(1)
+        time.sleep(20) # Sleep for 20 seconds before checking again

--- a/get_emails.py
+++ b/get_emails.py
@@ -2,13 +2,14 @@
 
 import setup  # pylint: disable=unused-import, wrong-import-order
 from typing import Optional
+import time
 from imap_tools import MailBox, AND
+import schedule
 import requests
 from loguru import logger
 import mysql.connector
 import pymysql
 from params import Params
-from pitney_ship import scrape_pitneyship
 from pirate_ship import scrape_pirateship
 
 
@@ -335,4 +336,7 @@ def authenticate() -> dict:
 
 if __name__ == "__main__":
     logger.info("Initializing Shipping Bot")
-    fetch_emails()
+    schedule.every().hour.do(fetch_emails)
+    while True:
+        schedule.run_pending()
+        time.sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ loguru==0.7.3
 mysql-connector==2.2.9
 PyMySQL==1.1.1
 requests==2.32.3
+schedule==1.2.2
 soupsieve==2.6
 typing_extensions==4.12.2
 urllib3==2.3.0


### PR DESCRIPTION
## Summary by Sourcery

Replace cron-based scheduling with an in-script scheduler, add graceful shutdown handling, and harden the Docker container by running as a non-root user.

New Features:
- Schedule fetch_emails to run every hour using the schedule library.
- Introduce SIGINT and SIGTERM handlers to enable graceful shutdown.

Enhancements:
- Eliminate reliance on external cron jobs in favor of internal scheduling.

Build:
- Update Dockerfile to run the application as a non-root user and adjust directory ownership.

Chores:
- Add schedule==1.2.2 to project dependencies.