### PR TITLE
Improve Dockerfile non-root user setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 COPY requirements.txt /app/
 
+RUN groupadd -r non-root && useradd -r -g non-root non-root -m
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
 
-RUN groupadd -r non-root && useradd -r -g non-root non-root
 RUN chown -R non-root:non-root /app
+RUN mkdir -p /home/non-root/.cache/pip /home/non-root/.local && chown -R non-root:non-root /home/non-root
 USER non-root
 CMD ["python", "get_emails.py"]


### PR DESCRIPTION
## Summary by Sourcery

Optimize Dockerfile by establishing a non-root user with a proper home directory and setting correct permissions for application and pip cache directories.

Enhancements:
- Create the non-root user earlier in the build with a home directory
- Add dedicated pip cache and local directories under the non-root home and apply ownership
- Remove duplicate non-root user creation step